### PR TITLE
Add tags support to document updates and update API schemas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Build and Run
+- `npm run build` - Compile TypeScript to JavaScript in `dist/` directory
+- `npm run dev` - Run the server in development mode using tsx
+- `npm run start` - Run the compiled server from `dist/index.js`
+
+### Testing
+- `npm run test` - Run Jest test suite
+- `npm run test:watch` - Run tests in watch mode for development
+- `npm run test:manual` - Execute manual testing script
+
+### Prerequisites
+- Node.js >=18 required
+- `READWISE_TOKEN` environment variable must be set for API access
+
+## API Reference
+
+**IMPORTANT**: Always check `docs/readwise-reader-api.md` before implementing or modifying any API-related code. This file contains the official Readwise Reader API documentation with endpoint specifications, parameters, and response formats.
+
+## Architecture Overview
+
+### Core Components
+
+**MCP Server Setup (`src/index.ts`)**
+- Entry point using `@modelcontextprotocol/sdk` with stdio transport
+- Handles tool registration and request routing
+- Implements error handling for all tool calls
+
+**Readwise API Client (`src/readwise-client.ts`)**
+- Centralized API client with rate limiting (20-50 req/min)
+- Automatic retry-after handling for 429 responses
+- Performance optimizations for bulk content fetching (limits full content to 5 docs when >5 total)
+- Structured error handling with typed responses
+
+**Tool System**
+- `src/tools/tool-definitions.ts` - MCP tool schemas with validation
+- `src/handlers/` - Modular request handlers:
+  - `document-handlers.ts` - CRUD operations for documents
+  - `tag-search-handlers.ts` - Tag listing and topic search functionality
+  - `index.ts` - Router dispatching to appropriate handlers
+
+**Content Processing (`src/utils/content-converter.ts`)**
+- Integration with r.jina.ai for LLM-friendly text conversion
+- HTML parsing with node-html-parser for fallback content extraction
+- Conditional content conversion based on document category
+
+### Data Flow Architecture
+
+1. **Tool Registration**: Tools defined with JSON schemas are registered with MCP server
+2. **Request Handling**: Requests routed through handler system based on tool name
+3. **API Integration**: Handlers use ReadwiseClient with automatic rate limiting
+4. **Content Enhancement**: Documents enriched with converted text content via jina.ai
+5. **Response Formation**: Structured responses with data and optional messages
+
+### Key Design Patterns
+
+**Performance Considerations**
+- `withFullContent` parameter triggers performance warnings and result limiting
+- Content conversion is conditional based on document type
+- Pagination support for large document collections
+
+**Error Handling Strategy**
+- Rate limiting with retry-after headers
+- Graceful degradation for content conversion failures
+- Structured error responses with context
+
+**Type Safety**
+- Comprehensive TypeScript interfaces in `src/types.ts`
+- API response typing with generic `APIResponse<T>` wrapper
+- Strict TypeScript configuration with ES2022 modules
+
+## Configuration Notes
+
+### Environment Setup
+- Uses ES modules (`"type": "module"` in package.json)
+- TypeScript compiled to ES2022 with Node module resolution
+- Jest configured for ESM with ts-jest preset
+
+### MCP Integration
+- Implements Model Context Protocol for Claude Desktop integration
+- Tools exposed: document CRUD, tag management, topic search
+- Requires stdio transport configuration in Claude Desktop settings
+
+### API Rate Limits
+- 20 requests/minute (general)
+- 50 requests/minute (CREATE/UPDATE operations)
+- Automatic handling via client with structured error messages

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Save a document (URL or HTML content) to Readwise Reader.
 - `html` (optional): HTML content of the document
 - `tags` (optional): Array of tags to add
 - `location` (optional): Location to save (`new`, `later`, `shortlist`, `archive`, `feed`)
-- `category` (optional): Document category (`article`, `book`, `tweet`, `pdf`, `email`, `youtube`, `podcast`)
+- `category` (optional): Document category (`article`, `email`, `rss`, `highlight`, `note`, `pdf`, `epub`, `tweet`, `video`)
 
 ### `readwise_list_documents`
 List documents from Readwise Reader with optional filtering. Returns complete document information including metadata and LLM-friendly text content.
@@ -107,8 +107,9 @@ Update a document in Readwise Reader.
 - `summary` (optional): New summary
 - `published_date` (optional): New published date (ISO 8601)
 - `image_url` (optional): New image URL
-- `location` (optional): New location
-- `category` (optional): New category
+- `location` (optional): New location (`new`, `later`, `archive`, `feed`) - **Note:** `shortlist` is not supported for updates
+- `category` (optional): New category (`article`, `email`, `rss`, `highlight`, `note`, `pdf`, `epub`, `tweet`, `video`)
+- `tags` (optional): Array of tags to assign to the document
 
 ### `readwise_delete_document`
 Delete a document from Readwise Reader.

--- a/docs/readwise-reader-api.md
+++ b/docs/readwise-reader-api.md
@@ -1,0 +1,569 @@
+# Reader API | Readwise
+The Reader API just supports saving new documents to Reader and fetching your documents. We will add more endpoints in the near future. If you have any questions, please [reach out :)](mailto:api@readwise.io)  
+Looking for the API docs for the original Readwise? [See here.](https://readwise.io/api_deets)
+
+Authentication
+--------------
+
+Set a header with key "Authorization" and value: "Token XXX" where XXX is your Readwise access token. You (or your users) can get that from here: [readwise.io/access\_token](https://readwise.io/access_token)
+
+If you want to check that a token is valid, just make a GET request to `https://readwise.io/api/v2/auth/` with the above header. You should receive a `204` response.
+
+Document CREATE
+---------------
+
+**Request**: `POST` to `https://readwise.io/api/v3/save/`
+
+**Parameters:** A JSON object with the following keys:
+
+
+
+* Key: url
+  * Type: string
+  * Description: The document's unique URL. If you don't have one, you can provide a made up value such as https://yourapp.com#document1
+  * Required: yes
+* Key: html
+  * Type: string
+  * Description: The document's content, in valid html (see examples). If you don't provide this, we will try to scrape the URL you provided to fetch html from the open web.
+  * Required: no
+* Key: should_clean_html
+  * Type: boolean
+  * Description: Only valid when html is provided. Pass true to have us automatically clean the html and parse the metadata (title/author) of the document for you. By default, this option is false.
+  * Required: no
+* Key: title
+  * Type: string
+  * Description: The document's title, it will overwrite the original title of the document                                        
+  * Required: no
+* Key: author
+  * Type: string
+  * Description: The document's author, it will overwrite the original author (if found                                            during the parsing step)                                        
+  * Required: no
+* Key: summary
+  * Type: string
+  * Description: Summary of the document
+  * Required: no
+* Key: published_date
+  * Type: date
+  * Description: A datetime representing when the document was published in the ISO 8601                                            format;                                            default timezone is UTC.Example:                                            "2020-07-14T20:11:24+00:00"
+  * Required: no
+* Key: image_url
+  * Type: string
+  * Description: An image URL to use as cover image
+  * Required: no
+* Key: location
+  * Type: string
+  * Description: One of: new, later, archive or feed. Default                                            is                                            new. Represents the initial location of the document (previously called triage_status).                                            Note: if you try to use a location the user doesn't have enabled in their settings, this value will be set to their default location.                                        
+  * Required: no
+* Key: category
+  * Type: string
+  * Description: One of: article, email, rss, highlight, note, pdf,epub, tweet or video. Default is guessed based on the URL, usually article.                                        
+  * Required: no
+* Key: saved_using
+  * Type: string
+  * Description: This value represents the source of the document
+  * Required: no
+* Key: tags
+  * Type: list
+  * Description: A list of strings containing tags, example: ["tag1", "tag2"]
+  * Required: no
+* Key: notes
+  * Type: string
+  * Description: A top-level note of the document
+  * Required: no
+
+
+**Response:**
+
+*   Status code: `201` or `200` if document already exist
+*   Created document details:
+
+```
+
+{
+    "id": "0000ffff2222eeee3333dddd4444",
+    "url": "https://read.readwise.io/new/read/0000ffff2222eeee3333dddd4444",
+}
+              
+```
+
+
+**Usage/Examples:**
+
+*   JavaScript
+
+```
+
+$.ajax({
+  url: 'https://readwise.io/api/v3/save/',
+  type: 'POST',
+  contentType: 'application/json',
+  beforeSend: function (xhr) {
+    xhr.setRequestHeader('Authorization', 'Token XXX');
+    },
+  data: JSON.stringify({
+    "url": "https://example.com/article/",
+    "html": "<div><h1>This article is awesome</h1><p>content here!</p></div>"
+    "tags": ["tag1", "tag2"]
+  }),
+  success: function (result) {console.log(result)},
+  error: function (error) {console.log(error)},
+});
+          
+```
+
+
+*   Python
+
+```
+
+import requests
+requests.post(
+    url="https://readwise.io/api/v3/save/",
+    headers={"Authorization": "Token XXX"},
+    json={
+        "url": "https://example.com/article/",
+        # No html is provided, so the url will be scraped to get the document's content.
+        "tags": ["tag3", "tag4"]
+    }
+)
+                    
+```
+
+
+*   Bash
+
+```
+
+$ curl -v https://readwise.io/api/v3/save/ -H "Authorization: Token XXX" -X POST -d '{"url": "https://example.com/article/"}' -H "Content-Type: application/json"
+                    
+```
+
+
+Document LIST
+-------------
+
+**Request**: `GET` to `https://readwise.io/api/v3/list/`
+
+**Parameters:** Usual query params:
+
+
+
+* Key: id
+  * Type: string
+  * Description: The document's unique id. Using this parameter it will return just one document, if found.
+  * Required: no
+* Key: updatedAfter
+  * Type: string (formatted as ISO 8601 date)
+  * Description: Fetch only documents updated after this date
+  * Required: no
+* Key: location
+  * Type: string
+  * Description: The document's location, could be one of: new, later, shortlist, archive, feed
+  * Required: no
+* Key: category
+  * Type: string
+  * Description: The document's category, could be one of: article, email, rss, highlight, note, pdf, epub, tweet, video
+  * Required: no
+* Key: tag
+  * Type: string
+  * Description: The document's tag key. Pass up to 5 tag parameters to find documents having all the tags listed. Pass empty value (?tag=) to find untagged documents. Use the Tag LIST endpoint to retrieve all tags available.
+  * Required: no
+* Key: pageCursor
+  * Type: string
+  * Description: A string returned by a previous request to this endpoint. Use it to get the next page of documents if there are too many for one request.
+  * Required: no
+* Key: withHtmlContent
+  * Type: boolean
+  * Description: Include the html_content field in each document's data. Please note that enabling this feature may slightly increase request processing time. Could be one of: true, false.
+  * Required: no
+* Key: withRawSourceUrl
+  * Type: boolean
+  * Description:                                             Include the raw_source_url field in each document's data, containing a direct Amazon S3 link to the raw document source file.                                            The link is empty for non-distributable documents, like Wisereads previews.                                            The link is valid for one hour.                                            Please note that enabling this feature may slightly increase request processing time.                                            Could be one of: true, false.                                        
+  * Required: no
+
+
+**Response:**
+
+*   Status code: `200`
+*   Please keep in mind that both highlights and notes made in Reader are also considered Documents. Highlights and notes will have \`parent\_id\` set, which is the Document id of the article/book/etc and highlight that they belong to, respectively.
+*   All dates are UTC unless otherwise stated.
+*   List of documents:
+
+```
+
+{
+    "count": 2304,
+    "nextPageCursor": "01gm6kjzabcd609yepjrmcgz8a",
+    "results": [
+        {
+            "id": "01gwfvp9pyaabcdgmx14f6ha0",
+            "url": "https://readiwise.io/feed/read/01gwfvp9pyaabcdgmx14f6ha0",
+            "source_url": "https://www.driverlesscrocodile.com/values/ends-and-meanings-3-alasdair-macintyre-virtue-mortality-and-story-in-heroic-societies/",
+            "title": "Ends and Meanings (3): Alasdair MacIntyre virtue, mortality and story in heroic societies",
+            "author": "Stuart Patience",
+            "source": "Reader RSS",
+            "category": "rss",
+            "location": "feed",
+            "tags": {},
+            "site_name": "Driverless Crocodile",
+            "word_count": 819,
+            "reading_time": "4 mins",
+            "created_at": "2023-03-26T21:02:51.618751+00:00",
+            "updated_at": "2023-03-26T21:02:55.453827+00:00",
+            "notes": "",
+            "published_date": "2023-03-22",
+            "summary": "Without … a place in the social order, ...",
+            "image_url": "https://i0.wp.com/www.driverlesscrocodile.com/wp-content/uploads/2019/10/cropped-driverlesscrocodile-icon-e1571123201159-4.jpg?fit=32%2C32&ssl=1",
+            "parent_id": null,
+            "reading_progress": 0.15,
+            "first_opened_at": null,
+            "last_opened_at": null,
+            "saved_at": "2023-03-26T21:02:51.618751+00:00",
+            "last_moved_at": "2023-03-27T21:03:52.118752+00:00",
+        },
+        {
+            "id": "01gkqtdz9xabcd5gt96khreyb",
+            "url": "https://readiwise.io/new/read/01gkqtdz9xabcd5gt96khreyb",
+            "source_url": "https://www.vanityfair.com/hollywood/2017/08/the-story-of-the-ducktales-theme-music",
+            "title": "The Story of the DuckTales Theme, History’s Catchiest Single Minute of Music",
+            "author": "Darryn King",
+            "source": "Reader add from import URL",
+            "category": "article",
+            "location": "new",
+            "tags": {},
+            "site_name": "Vanity Fair",
+            "word_count": 2678,
+            "reading_time": "11 mins",
+            "created_at": "2022-12-08T02:53:29.639650+00:00",
+            "updated_at": "2022-12-13T20:37:42.544298+00:00",
+            "published_date": "2017-08-09",
+            "notes": "A sample note",
+            "summary": "A woo-hoo heard around the world.",
+            "image_url": "https://media.vanityfair.com/photos/598b1452f7f0a433bd4d149c/16:9/w_1280,c_limit/t-ducktales-woohoo-song.png",
+            "parent_id": null,
+            "reading_progress": 0.5,
+            "first_opened_at": "2023-03-26T21:02:51.618751+00:00",
+            "last_opened_at": "2023-03-29T21:02:51.618751+00:00",
+            "saved_at": "2023-03-26T21:02:51.618751+00:00",
+            "last_moved_at": "2023-03-27T21:03:52.118752+00:00",
+        },
+        {
+            "id": "01gkqt8nbms4t698abcdvcswvf",
+            "url": "https://readwise.io/new/read/01gkqt8nbms4t698abcdvcswvf",
+            "source_url": "https://www.vanityfair.com/news/2022/10/covid-origins-investigation-wuhan-lab",
+            "title": "COVID-19 Origins: Investigating a “Complex and Grave Situation” Inside a Wuhan Lab",
+            "author": "Condé Nast",
+            "source": "Reader add from import URL",
+            "category": "article",
+            "location": "new",
+            "tags": {},
+            "site_name": "Vanity Fair",
+            "word_count": 9601,
+            "reading_time": "37 mins",
+            "created_at": "2022-12-08T02:50:35.662027+00:00",
+            "updated_at": "2023-03-22T13:29:41.827456+00:00",
+            "published_date": "2022-10-28",
+            "notes": "",
+            "summary": "The Wuhan Institute of Virology, the cutting-edge ...",
+            "image_url": "https://media.vanityfair.com/photos/63599642578d980751943b65/16:9/w_1280,c_limit/vf-1022-covid-trackers-site-story.jpg",
+            "parent_id": null,
+            "reading_progress": 0,
+            "first_opened_at": "2023-03-26T21:02:51.618751+00:00",
+            "last_opened_at": "2023-03-26T21:02:51.618751+00:00",
+            "saved_at": "2023-03-26T21:02:51.618751+00:00",
+            "last_moved_at": "2023-03-27T21:03:52.118752+00:00",
+        }
+    ]
+}
+              
+```
+
+
+**Usage/Examples:**
+
+*   JavaScript
+
+```
+
+const token = "XXX"; // use your access token here
+
+const fetchDocumentListApi = async (updatedAfter=null, location=null) => {
+    let fullData = [];
+    let nextPageCursor = null;
+
+    while (true) {
+      const queryParams = new URLSearchParams();
+      if (nextPageCursor) {
+        queryParams.append('pageCursor', nextPageCursor);
+      }
+      if (updatedAfter) {
+        queryParams.append('updatedAfter', updatedAfter);
+      }
+      if (location) {
+        queryParams.append('location', location);
+      }
+      console.log('Making export api request with params ' + queryParams.toString());
+      const response = await fetch('https://readwise.io/api/v3/list/?' + queryParams.toString(), {
+        method: 'GET',
+        headers: {
+          Authorization: `Token ${token}`,
+        },
+      });
+      const responseJson = await response.json();
+      fullData.push(...responseJson['results']);
+      nextPageCursor = responseJson['nextPageCursor'];
+      if (!nextPageCursor) {
+        break;
+      }
+    }
+    return fullData;
+};
+
+// Get all of a user's documents from all time
+const allData = await fetchDocumentListApi();
+
+// Get all of a user's archived documents
+const archivedData = await fetchDocumentListApi(null, 'archive');
+
+// Later, if you want to get new documents updated after some date, do this:
+const docsAfterDate = new Date(Date.now() - 24 * 60 * 60 * 1000);  // use your own stored date
+const newData = await fetchDocumentListApi(docsAfterDate.toISOString());
+          
+```
+
+
+*   Python
+
+```
+
+import datetime
+import requests  # This may need to be installed from pip
+
+token = 'XXX'
+
+def fetch_reader_document_list_api(updated_after=None, location=None):
+    full_data = []
+    next_page_cursor = None
+    while True:
+        params = {}
+        if next_page_cursor:
+            params['pageCursor'] = next_page_cursor
+        if updated_after:
+            params['updatedAfter'] = updated_after
+        if location:
+            params['location'] = location
+        print("Making export api request with params " + str(params) + "...")
+        response = requests.get(
+            url="https://readwise.io/api/v3/list/",
+            params=params,
+            headers={"Authorization": f"Token {token}"}, verify=False
+        )
+        full_data.extend(response.json()
+['results'])
+        next_page_cursor = response.json().get('nextPageCursor')
+        if not next_page_cursor:
+            break
+    return full_data
+
+# Get all of a user's documents from all time
+all_data = fetch_reader_document_list_api()
+
+# Get all of a user's archived documents
+archived_data = fetch_reader_document_list_api(location='archive')
+
+# Later, if you want to get new documents updated after some date, do this:
+docs_after_date = datetime.datetime.now() - datetime.timedelta(days=1)  # use your own stored date
+new_data = fetch_reader_document_list_api(docs_after_date.isoformat())
+                    
+```
+
+
+*   Bash
+
+```
+
+$ curl -v https://readwise.io/api/v3/list/?location=later -H "Authorization: Token XXX" -H "Content-Type: application/json"
+                    
+```
+
+
+Document UPDATE
+---------------
+
+Use this API to update specific fields from the list below.  
+Fields omitted from the request will remain unchanged.
+
+**Request**: `PATCH` to `https://readwise.io/api/v3/update/<document_id>/`
+
+**Parameters:** A JSON object with the following keys:
+
+
+
+* Key: title
+  * Type: string
+  * Description: The document's title, it will overwrite the original title of the document                                        
+  * Required: no
+* Key: author
+  * Type: string
+  * Description: The document's author, it will overwrite the original author (if found                                            during the parsing step)                                        
+  * Required: no
+* Key: summary
+  * Type: string
+  * Description: Summary of the document
+  * Required: no
+* Key: published_date
+  * Type: date
+  * Description: A datetime representing when the document was published in the ISO 8601                                            format;                                            default timezone is UTC.Example:                                            "2020-07-14T20:11:24+00:00"
+  * Required: no
+* Key: image_url
+  * Type: string
+  * Description: An image URL to use as cover image
+  * Required: no
+* Key: seen
+  * Type: boolean
+  * Description: Mark the document as seen/unseen (without deleting it). Setting true will populate first_opened_at / last_opened_at; setting false will clear them.
+  * Required: no
+* Key: location
+  * Type: string
+  * Description: One of: new, later, archive or feed.                                            Represents the current location of the document (previously called triage_status).                                            Note: if you try to use a location the user doesn't have enabled in their settings, this value will be set to their default location.                                        
+  * Required: no
+* Key: category
+  * Type: string
+  * Description: One of: article, email, rss, highlight, note, pdf,epub, tweet or video.                                        
+  * Required: no
+* Key: tags
+  * Type: list
+  * Description: A list of strings containing tags, example: ["tag1", "tag2"]
+  * Required: no
+
+
+**Response:**
+
+*   Status code: `200`
+*   Updated document details:
+
+```
+
+{
+    "id": "0000ffff2222eeee3333dddd4444",
+    "url": "https://read.readwise.io/new/read/0000ffff2222eeee3333dddd4444",
+}
+              
+```
+
+
+**Usage/Examples:**
+
+*   JavaScript
+
+```
+
+$.ajax({
+  url: 'https://readwise.io/api/v3/update/0000ffff2222eeee3333dddd4444',
+  type: 'PATCH',
+  contentType: 'application/json',
+  beforeSend: function (xhr) {
+    xhr.setRequestHeader('Authorization', 'Token XXX');
+    },
+  data: JSON.stringify({
+    "title": "Updated title",
+    "location": "new"
+  }),
+  success: function (result) {console.log(result)},
+  error: function (error) {console.log(error)},
+});
+          
+```
+
+
+*   Python
+
+```
+
+import requests
+requests.patch(
+    url="https://readwise.io/api/v3/update/0000ffff2222eeee3333dddd4444",
+    headers={"Authorization": "Token XXX"},
+    json={
+        "title": "Updated title",
+        "location": "new",
+    }
+)
+                    
+```
+
+
+*   Bash
+
+```
+
+$ curl -v https://readwise.io/api/v3/update/0000ffff2222eeee3333dddd4444 -H "Authorization: Token XXX" -X PATCH -d '{"title": "Updated title"}' -H "Content-Type: application/json"
+                    
+```
+
+
+Document DELETE
+---------------
+
+**Request**: `DELETE` to `https://readwise.io/api/v3/delete/<document_id>/`
+
+**Response:**
+
+*   Status code: `204`
+
+**Usage/Examples:**
+
+*   JavaScript
+
+```
+
+$.ajax({
+  url: 'https://readwise.io/api/v3/delete/0000ffff2222eeee3333dddd4444',
+  type: 'DELETE',
+  beforeSend: function (xhr) {
+    xhr.setRequestHeader('Authorization', 'Token XXX');
+    },
+  success: function (result) {console.log(result)},
+  error: function (error) {console.log(error)},
+});
+          
+```
+
+
+*   Python
+
+```
+
+import requests
+requests.delete(
+    url="https://readwise.io/api/v3/delete/0000ffff2222eeee3333dddd4444",
+    headers={"Authorization": "Token XXX"},
+)
+                    
+```
+
+
+*   Bash
+
+```
+
+$ curl -v https://readwise.io/api/v3/delete/0000ffff2222eeee3333dddd4444 -H "Authorization: Token XXX" -X DELETE
+                    
+```
+
+
+Rate Limiting
+-------------
+
+The default base rate is 20 requests per minute (per access token) but the `Document CREATE` and `Document UPDATE` endpoints have higher limits of 50 requests per minute (per access token). You can check `Retry-After` header in the 429 response to get the number of seconds to wait for.
+
+Webhooks
+--------
+
+Receive real-time notifications about your highlights and documents via webhooks. Configure webhooks to automatically receive updates when highlights are created, updated, or deleted.
+
+For detailed documentation on setting up and using webhooks, including available event types, payload formats, and best practices, please visit:
+
+[Webhooks Documentation →](https://docs.readwise.io/readwise/docs/webhooks)
+
+You can also configure your webhooks directly in your account settings: [Configure Webhooks](https://readwise.io/webhook)

--- a/src/handlers/document-handlers.ts
+++ b/src/handlers/document-handlers.ts
@@ -212,23 +212,4 @@ export async function handleUpdateDocument(args: any) {
   };
 }
 
-export async function handleDeleteDocument(args: any) {
-  const client = initializeClient();
-  const { id } = args as { id: string };
-  const response = await client.deleteDocument(id);
-
-  let responseText = `Document ${id} deleted successfully!`;
-  
-  if (response.messages && response.messages.length > 0) {
-    responseText += '\n\nMessages:\n' + response.messages.map(msg => `${msg.type.toUpperCase()}: ${msg.content}`).join('\n');
-  }
-
-  return {
-    content: [
-      {
-        type: 'text',
-        text: responseText,
-      },
-    ],
-  };
-} 
+ 

--- a/src/handlers/document-handlers.ts
+++ b/src/handlers/document-handlers.ts
@@ -129,6 +129,7 @@ export async function handleListDocuments(args: any) {
         tags: doc.tags,
         site_name: doc.site_name,
         word_count: doc.word_count,
+        reading_time: doc.reading_time,
         created_at: doc.created_at,
         updated_at: doc.updated_at,
         published_date: doc.published_date,
@@ -143,6 +144,10 @@ export async function handleListDocuments(args: any) {
         saved_at: doc.saved_at,
         last_moved_at: doc.last_moved_at,
       };
+
+      if (params.withRawSourceUrl && doc.raw_source_url) {
+        result.raw_source_url = doc.raw_source_url;
+      }
       
       if (shouldIncludeContent) {
         result.content = content; // LLM-friendly text content instead of raw HTML

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,31 +1,38 @@
-import { 
-  handleSaveDocument, 
-  handleListDocuments, 
-  handleUpdateDocument, 
-  handleDeleteDocument 
+import {
+  handleSaveDocument,
+  handleListDocuments,
+  handleUpdateDocument
 } from './document-handlers.js';
-import { handleListTags, handleTopicSearch } from './tag-search-handlers.js';
+import {
+  handleListTags,
+  handleTopicSearch,
+  handleUpdateDocumentTags,
+  handleBulkUpdateTags
+} from './tag-search-handlers.js';
 
 export async function handleToolCall(name: string, args: any) {
   switch (name) {
     case 'readwise_save_document':
       return handleSaveDocument(args);
-      
+
     case 'readwise_list_documents':
       return handleListDocuments(args);
-      
+
     case 'readwise_update_document':
       return handleUpdateDocument(args);
-      
-    case 'readwise_delete_document':
-      return handleDeleteDocument(args);
-      
+
     case 'readwise_list_tags':
       return handleListTags(args);
-      
+
     case 'readwise_topic_search':
       return handleTopicSearch(args);
-      
+
+    case 'readwise_update_document_tags':
+      return handleUpdateDocumentTags(args);
+
+    case 'readwise_bulk_update_tags':
+      return handleBulkUpdateTags(args);
+
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/src/readwise-client.ts
+++ b/src/readwise-client.ts
@@ -1,9 +1,10 @@
-import { 
-  ReadwiseDocument, 
-  CreateDocumentRequest, 
-  UpdateDocumentRequest, 
-  ListDocumentsParams, 
+import {
+  ReadwiseDocument,
+  CreateDocumentRequest,
+  UpdateDocumentRequest,
+  ListDocumentsParams,
   ListDocumentsResponse,
+  ListTagsResponse,
   ReadwiseTag,
   ReadwiseConfig,
   APIResponse,
@@ -198,8 +199,8 @@ export class ReadwiseClient {
 
   async listTags(): Promise<APIResponse<ReadwiseTag[]>> {
     try {
-      const result = await this.makeRequest<ReadwiseTag[]>('/tags/');
-      return this.createResponse(result);
+      const result = await this.makeRequest<ListTagsResponse>('/tags/');
+      return this.createResponse(result.results);
     } catch (error) {
       if (error instanceof Error && error.message.startsWith('RATE_LIMIT:')) {
         const seconds = parseInt(error.message.split(':')[1], 10);

--- a/src/readwise-client.ts
+++ b/src/readwise-client.ts
@@ -182,21 +182,6 @@ export class ReadwiseClient {
     }
   }
 
-  async deleteDocument(id: string): Promise<APIResponse<void>> {
-    try {
-      await this.makeRequest(`/delete/${id}/`, {
-        method: 'DELETE',
-      });
-      return this.createResponse(undefined);
-    } catch (error) {
-      if (error instanceof Error && error.message.startsWith('RATE_LIMIT:')) {
-        const seconds = parseInt(error.message.split(':')[1], 10);
-        throw new Error(`Rate limit exceeded. Too many requests. Please retry after ${seconds} seconds.`);
-      }
-      throw error;
-    }
-  }
-
   async listTags(): Promise<APIResponse<ReadwiseTag[]>> {
     try {
       const result = await this.makeRequest<ListTagsResponse>('/tags/');

--- a/src/tools/tool-definitions.ts
+++ b/src/tools/tool-definitions.ts
@@ -174,21 +174,6 @@ export const tools: Tool[] = [
     },
   },
   {
-    name: 'readwise_delete_document',
-    description: 'Delete a document from Readwise Reader',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        id: {
-          type: 'string',
-          description: 'Document ID to delete',
-        },
-      },
-      required: ['id'],
-      additionalProperties: false,
-    },
-  },
-  {
     name: 'readwise_list_tags',
     description: 'List all tags from Readwise Reader',
     inputSchema: {
@@ -211,6 +196,58 @@ export const tools: Tool[] = [
         },
       },
       required: ['searchTerms'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'readwise_update_document_tags',
+    description: 'Update tags for a single document. Only modifies tags, leaving all other document properties unchanged.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Document ID to update tags for',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Tags to apply to the document (e.g., ["tag1", "tag2"])',
+        },
+        mode: {
+          type: 'string',
+          enum: ['replace', 'add'],
+          description: 'Mode of operation: "replace" replaces all existing tags, "add" adds to existing tags. Default: "replace"',
+        },
+      },
+      required: ['id', 'tags'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: 'readwise_bulk_update_tags',
+    description: 'Update tags for multiple documents at once. Only modifies tags, leaving all other document properties unchanged.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        documentIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'List of document IDs to update tags for',
+          minItems: 1,
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Tags to apply to all specified documents (e.g., ["tag1", "tag2"])',
+        },
+        mode: {
+          type: 'string',
+          enum: ['replace', 'add'],
+          description: 'Mode of operation: "replace" replaces all existing tags, "add" adds to existing tags. Default: "replace"',
+        },
+      },
+      required: ['documentIds', 'tags'],
       additionalProperties: false,
     },
   },

--- a/src/tools/tool-definitions.ts
+++ b/src/tools/tool-definitions.ts
@@ -27,7 +27,7 @@ export const tools: Tool[] = [
         },
         category: {
           type: 'string',
-          enum: ['article', 'book', 'tweet', 'pdf', 'email', 'youtube', 'podcast'],
+          enum: ['article', 'email', 'rss', 'highlight', 'note', 'pdf', 'epub', 'tweet', 'video'],
           description: 'Category of the document (auto-detected if not specified)',
         },
       },
@@ -60,7 +60,7 @@ export const tools: Tool[] = [
         },
         category: {
           type: 'string',
-          enum: ['article', 'book', 'tweet', 'pdf', 'email', 'youtube', 'podcast'],
+          enum: ['article', 'email', 'rss', 'highlight', 'note', 'pdf', 'epub', 'tweet', 'video'],
           description: 'Filter by document category',
         },
         tag: {
@@ -115,13 +115,18 @@ export const tools: Tool[] = [
         },
         location: {
           type: 'string',
-          enum: ['new', 'later', 'shortlist', 'archive', 'feed'],
+          enum: ['new', 'later', 'archive', 'feed'],
           description: 'New location for the document',
         },
         category: {
           type: 'string',
-          enum: ['article', 'book', 'tweet', 'pdf', 'email', 'youtube', 'podcast'],
+          enum: ['article', 'email', 'rss', 'highlight', 'note', 'pdf', 'epub', 'tweet', 'video'],
           description: 'New category for the document',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Tags to assign to the document',
         },
       },
       required: ['id'],

--- a/src/tools/tool-definitions.ts
+++ b/src/tools/tool-definitions.ts
@@ -9,26 +9,58 @@ export const tools: Tool[] = [
       properties: {
         url: {
           type: 'string',
-          description: 'URL of the document to save',
+          description: 'URL of the document to save. If you don\'t have one, provide a made up value such as https://yourapp.com#document1',
         },
         html: {
           type: 'string',
-          description: 'HTML content of the document (optional)',
+          description: 'HTML content of the document. If not provided, Readwise will try to scrape the URL.',
         },
-        tags: {
-          type: 'array',
-          items: { type: 'string' },
-          description: 'Tags to add to the document',
+        should_clean_html: {
+          type: 'boolean',
+          description: 'Only valid when html is provided. Pass true to have Readwise automatically clean the HTML and parse the metadata (title/author). Default: false.',
+        },
+        title: {
+          type: 'string',
+          description: 'Document title. Will overwrite the original title.',
+        },
+        author: {
+          type: 'string',
+          description: 'Document author. Will overwrite the original author if found during parsing.',
+        },
+        summary: {
+          type: 'string',
+          description: 'Summary of the document.',
+        },
+        published_date: {
+          type: 'string',
+          description: 'Published date in ISO 8601 format (e.g., "2020-07-14T20:11:24+00:00"). Default timezone is UTC.',
+        },
+        image_url: {
+          type: 'string',
+          description: 'Image URL to use as cover image.',
         },
         location: {
           type: 'string',
-          enum: ['new', 'later', 'shortlist', 'archive', 'feed'],
-          description: 'Location to save the document (default: new)',
+          enum: ['new', 'later', 'archive', 'feed'],
+          description: 'Location to save the document (default: new). Note: if the user doesn\'t have the location enabled, it will be set to their default.',
         },
         category: {
           type: 'string',
           enum: ['article', 'email', 'rss', 'highlight', 'note', 'pdf', 'epub', 'tweet', 'video'],
-          description: 'Category of the document (auto-detected if not specified)',
+          description: 'Category of the document (auto-detected based on URL if not specified, usually article).',
+        },
+        saved_using: {
+          type: 'string',
+          description: 'Source of the document (e.g., app name or integration).',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Tags to add to the document (e.g., ["tag1", "tag2"]).',
+        },
+        notes: {
+          type: 'string',
+          description: 'Top-level note for the document.',
         },
       },
       required: ['url'],
@@ -73,11 +105,15 @@ export const tools: Tool[] = [
         },
         withHtmlContent: {
           type: 'boolean',
-          description: '⚠️ PERFORMANCE WARNING: Include HTML content in the response. This significantly slows down the API. Only use when explicitly requested by the user or when raw HTML is specifically needed for the task.',
+          description: '⚠️ PERFORMANCE WARNING: Include HTML content in the response. This may slightly increase request processing time.',
+        },
+        withRawSourceUrl: {
+          type: 'boolean',
+          description: 'Include a direct Amazon S3 link to the raw document source file (valid for 1 hour). Empty for non-distributable documents. May slightly increase request processing time.',
         },
         withFullContent: {
           type: 'boolean',
-          description: '⚠️ PERFORMANCE WARNING: Include full converted text content in the response. This significantly slows down the API as it fetches and processes each document\'s content. Only use when explicitly requested by the user or when document content is specifically needed for analysis/reading. Default: false for performance.',
+          description: '⚠️ PERFORMANCE WARNING: Include full converted text content in the response. This significantly slows down the API as it fetches and processes each document\'s content via jina.ai. Only use when document content is specifically needed. Default: false.',
         },
       },
       additionalProperties: false,
@@ -85,7 +121,7 @@ export const tools: Tool[] = [
   },
   {
     name: 'readwise_update_document',
-    description: 'Update a document in Readwise Reader',
+    description: 'Update a document in Readwise Reader. Fields omitted from the request will remain unchanged.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -107,16 +143,20 @@ export const tools: Tool[] = [
         },
         published_date: {
           type: 'string',
-          description: 'New published date (ISO 8601)',
+          description: 'New published date in ISO 8601 format (e.g., "2020-07-14T20:11:24+00:00"). Default timezone is UTC.',
         },
         image_url: {
           type: 'string',
-          description: 'New image URL for the document',
+          description: 'New image URL for the document cover',
+        },
+        seen: {
+          type: 'boolean',
+          description: 'Mark the document as seen/unseen. Setting true will populate first_opened_at/last_opened_at; setting false will clear them.',
         },
         location: {
           type: 'string',
           enum: ['new', 'later', 'archive', 'feed'],
-          description: 'New location for the document',
+          description: 'New location for the document. Note: if the user doesn\'t have the location enabled, it will be set to their default.',
         },
         category: {
           type: 'string',
@@ -126,7 +166,7 @@ export const tools: Tool[] = [
         tags: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Tags to assign to the document',
+          description: 'Tags to assign to the document (e.g., ["tag1", "tag2"])',
         },
       },
       required: ['id'],

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,7 +9,7 @@ export interface ReadwiseDocument {
   published_date?: string | number;
   image_url?: string;
   location: 'new' | 'later' | 'shortlist' | 'archive' | 'feed';
-  category?: 'article' | 'book' | 'tweet' | 'pdf' | 'email' | 'youtube' | 'podcast' | 'video';
+  category?: 'article' | 'email' | 'rss' | 'highlight' | 'note' | 'pdf' | 'epub' | 'tweet' | 'video';
   tags?: string[] | object;
   site_name?: string;
   word_count?: number | null;
@@ -30,7 +30,7 @@ export interface CreateDocumentRequest {
   html?: string;
   tags?: string[];
   location?: 'new' | 'later' | 'shortlist' | 'archive' | 'feed';
-  category?: 'article' | 'book' | 'tweet' | 'pdf' | 'email' | 'youtube' | 'podcast';
+  category?: 'article' | 'email' | 'rss' | 'highlight' | 'note' | 'pdf' | 'epub' | 'tweet' | 'video';
 }
 
 export interface UpdateDocumentRequest {
@@ -39,8 +39,9 @@ export interface UpdateDocumentRequest {
   summary?: string;
   published_date?: string;
   image_url?: string;
-  location?: 'new' | 'later' | 'shortlist' | 'archive' | 'feed';
-  category?: 'article' | 'book' | 'tweet' | 'pdf' | 'email' | 'youtube' | 'podcast';
+  location?: 'new' | 'later' | 'archive' | 'feed';
+  category?: 'article' | 'email' | 'rss' | 'highlight' | 'note' | 'pdf' | 'epub' | 'tweet' | 'video';
+  tags?: string[];
 }
 
 export interface ListDocumentsParams {
@@ -48,7 +49,7 @@ export interface ListDocumentsParams {
   updatedAfter?: string;
   addedAfter?: string;
   location?: 'new' | 'later' | 'shortlist' | 'archive' | 'feed';
-  category?: 'article' | 'book' | 'tweet' | 'pdf' | 'email' | 'youtube' | 'podcast';
+  category?: 'article' | 'email' | 'rss' | 'highlight' | 'note' | 'pdf' | 'epub' | 'tweet' | 'video';
   tag?: string;
   pageCursor?: string;
   withHtmlContent?: boolean;
@@ -63,7 +64,7 @@ export interface ListDocumentsResponse {
 }
 
 export interface ReadwiseTag {
-  id: string;
+  key: string;
   name: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface ReadwiseDocument {
   tags?: string[] | object;
   site_name?: string;
   word_count?: number | null;
+  reading_time?: string;
   created_at: string;
   updated_at: string;
   notes?: string;
@@ -23,14 +24,23 @@ export interface ReadwiseDocument {
   saved_at?: string;
   last_moved_at?: string;
   html_content?: string;
+  raw_source_url?: string;
 }
 
 export interface CreateDocumentRequest {
   url: string;
   html?: string;
-  tags?: string[];
-  location?: 'new' | 'later' | 'shortlist' | 'archive' | 'feed';
+  should_clean_html?: boolean;
+  title?: string;
+  author?: string;
+  summary?: string;
+  published_date?: string;
+  image_url?: string;
+  location?: 'new' | 'later' | 'archive' | 'feed';
   category?: 'article' | 'email' | 'rss' | 'highlight' | 'note' | 'pdf' | 'epub' | 'tweet' | 'video';
+  saved_using?: string;
+  tags?: string[];
+  notes?: string;
 }
 
 export interface UpdateDocumentRequest {
@@ -39,6 +49,7 @@ export interface UpdateDocumentRequest {
   summary?: string;
   published_date?: string;
   image_url?: string;
+  seen?: boolean;
   location?: 'new' | 'later' | 'archive' | 'feed';
   category?: 'article' | 'email' | 'rss' | 'highlight' | 'note' | 'pdf' | 'epub' | 'tweet' | 'video';
   tags?: string[];
@@ -53,6 +64,7 @@ export interface ListDocumentsParams {
   tag?: string;
   pageCursor?: string;
   withHtmlContent?: boolean;
+  withRawSourceUrl?: boolean;
   withFullContent?: boolean;
   limit?: number;
 }
@@ -61,6 +73,12 @@ export interface ListDocumentsResponse {
   count: number;
   nextPageCursor?: string;
   results: ReadwiseDocument[];
+}
+
+export interface ListTagsResponse {
+  count: number;
+  nextPageCursor?: string;
+  results: ReadwiseTag[];
 }
 
 export interface ReadwiseTag {


### PR DESCRIPTION
Fixes #5 

  ## Summary
  - Add tags support to document update operations
  - Fix tag response format to match current API specification
  - Update category and location enums to reflect latest API changes

  ## Changes Made
  - **Tags Support**: Added `tags` parameter to `UpdateDocumentRequest` interface and `readwise_update_document` tool schema
  - **Tag Format Fix**: Updated `ReadwiseTag` interface to use `key` field instead of `id` to match API response format
  - **Category Updates**:
    - Removed deprecated categories: `book`, `youtube`, `podcast`
    - Added new categories: `rss`, `highlight`, `note`, `epub`
  - **Location Constraints**: Removed `shortlist` from update location enum (not supported by update endpoint)
  - **Documentation**: Updated README.md to reflect API changes and limitations

  ## API Reference
  Changes based on the official Readwise Reader API documentation: https://readwise.io/reader_api

  Updated on: 2025-09-12

  ## Breaking Changes
  - `ReadwiseTag.id` field renamed to `ReadwiseTag.key`
  - Some category values no longer supported in favor of new API categories
  - Document updates no longer support `shortlist` location (filtering still supports it)